### PR TITLE
Fix generic Option example to make it compile. (std::os -> std::env)

### DIFF
--- a/presentation/chapters/shared/code/generics-basics/3.rs
+++ b/presentation/chapters/shared/code/generics-basics/3.rs
@@ -4,6 +4,6 @@ enum Option<T> {
 }
 
 fn main() {
-    let args = std::os::args;
-    println!("{:?} {:?}", args.at(0), args.at(1))
+    let mut args = std::env::args;
+    println!("{:?} {:?}", args.nth(0), args.nth(0))
 }


### PR DESCRIPTION
I am not sure if this is the right approach, but this is what seems to make the example work.