### PR TITLE
Fix function example

### DIFF
--- a/presentation/chapters/shared/code/functions/5.rs
+++ b/presentation/chapters/shared/code/functions/5.rs
@@ -1,3 +1,8 @@
 fn prints_anything<T: Debug>(thing: T) {
     println!("{:?}", thing);
 }
+
+fn prints_anything<T>(thing: T)
+  where T: Debug {
+    println!("{:?}", thing);
+}


### PR DESCRIPTION
Quickly fix the missing `where`syntax for the generic function example.