### PR TITLE
Remove escaping to render list correctly

### DIFF
--- a/presentation/chapters/en-US/drop-panic-abort.chapter
+++ b/presentation/chapters/en-US/drop-panic-abort.chapter
@@ -60,9 +60,9 @@ Rust also has another error mechanism: `panic!`
 
 In case of a panic, the following happens:
 
-\* The current thread immediately halts
-\* The stack is unwound
-\* All affected values are dropped and their destructors run
+* The current thread immediately halts
+* The stack is unwound
+* All affected values are dropped and their destructors run
 
 ---
 


### PR DESCRIPTION
Not sure why it was escaped in the first place, but without it now renders as a list