### PR TITLE
No need to escape the hash

### DIFF
--- a/presentation/chapters/de-DE/smart-pointers.chapter
+++ b/presentation/chapters/de-DE/smart-pointers.chapter
@@ -67,5 +67,5 @@ Nutzen Sie `Arc` nicht "auf Verdacht" - `rustc` lehnt Code ab, der `Rc` über Th
 -   Copy-on-write
 -   Abstrahiert über Leihe und Besitz
 -   Klont enthaltene Daten nur bei Notwendigkeit
--   https://doc.rust-lang.org/std/borrow/enum.Cow.html\#examples
+-   https://doc.rust-lang.org/std/borrow/enum.Cow.html#examples
 

--- a/presentation/chapters/en-US/smart-pointers.chapter
+++ b/presentation/chapters/en-US/smart-pointers.chapter
@@ -67,5 +67,5 @@ Do not use `Arc` on a hunch. `rustc` rejects code using `Rc` over thread boundar
 -   Copy-on-write
 -   Abstracts over Borrowing and Ownership
 -   Clones Data only when necessary
--   https://doc.rust-lang.org/std/borrow/enum.Cow.html\#examples
+-   https://doc.rust-lang.org/std/borrow/enum.Cow.html#examples
 

--- a/presentation/chapters/es-ES/smart-pointers.chapter
+++ b/presentation/chapters/es-ES/smart-pointers.chapter
@@ -67,5 +67,5 @@ No utilice `Arc` en una corazonada. `rustc` rechaza codigo usando `Rc` a través
 -   Copia-al-escribir
 -   Abstrae por encima de préstamo y propiedad (Borrowing and Ownership)
 -   Clona datos sólo cuando es necesario
--   https://doc.rust-lang.org/std/borrow/enum.Cow.html\#examples
+-   https://doc.rust-lang.org/std/borrow/enum.Cow.html#examples
 


### PR DESCRIPTION
With escaping the link does not work because it adds an addtional
forward slash