### PR TITLE
Set document title from first heading of rendered slide

### DIFF
--- a/presentation/js/locale-selector.js
+++ b/presentation/js/locale-selector.js
@@ -46,6 +46,7 @@ const LocaleSelector = (function(){
       const observer = new MutationObserver((records, observer) =>{
         if(records.length > 0 && records[0].addedNodes){
           this.addLocaleSelector(records[0].addedNodes[0]);
+          this.setDocumentTitle(records[0].addedNodes[0]);
           observer.disconnect();
         }
       });
@@ -63,6 +64,12 @@ const LocaleSelector = (function(){
           window.location = location;
         }
       });
+    },
+    setDocumentTitle: function(slide){
+      var title = slide.querySelector("h1");
+      if (title && title.innerText.length) {
+        document.title = title.innerText + ' - ' + document.title;
+      }
     }
   };
 


### PR DESCRIPTION
This prefixes the document title with the current slide's title, visible in the browser's header and tab. That makes it easier to differentiate multiple chapters when opening them in tabs.